### PR TITLE
reduce and reduceRight support other accumulator types, fix #10

### DIFF
--- a/modern-async.d.ts
+++ b/modern-async.d.ts
@@ -152,11 +152,13 @@ declare module "mapSeries" {
 }
 declare module "reduce" {
     export default reduce;
-    function reduce<V>(iterable: Iterable<V> | AsyncIterable<V>, reducer: (accumulator: V, value: V, index: number, iterable: Iterable<V> | AsyncIterable<V>) => Promise<V> | V, initial?: V): Promise<V>;
+    function reduce<V, A>(iterable: Iterable<V> | AsyncIterable<V>,reducer: (accumulator: A, value: V, index: number, iterable: Iterable<V> | AsyncIterable<V>) => Promise<A> | A, initial: A): Promise<A>;
+    function reduce<V>(iterable: Iterable<V> | AsyncIterable<V>, reducer: (accumulator: V, value: V, index: number, iterable: Iterable<V> | AsyncIterable<V>) => Promise<V> | V): Promise<V>;
 }
 declare module "reduceRight" {
     export default reduceRight;
-    function reduceRight<V>(iterable: Iterable<V> | AsyncIterable<V>, reducer: (accumulator: V, value: V, index: number, iterable: Iterable<V> | AsyncIterable<V>) => Promise<V> | V, initial?: V): Promise<V>;
+    function reduceRight<V, A>(iterable: Iterable<V> | AsyncIterable<V>,reducer: (accumulator: A, value: V, index: number, iterable: Iterable<V> | AsyncIterable<V>) => Promise<A> | A, initial: A): Promise<A>;
+    function reduceRight<V>(iterable: Iterable<V> | AsyncIterable<V>, reducer: (accumulator: V, value: V, index: number, iterable: Iterable<V> | AsyncIterable<V>) => Promise<V> | V): Promise<V>;
 }
 declare module "sleepCancellable" {
     export default sleepCancellable;


### PR DESCRIPTION
**What does this pull request add, improve or fixes?**

Fixes https://github.com/nicolas-van/modern-async/issues/10

**Can you explain why this improvement or fix may be useful?**

As discussed in the issue. Note that the solution involves overloading the `reduce` and `reduceRight` definitions to have versions that don't include an `initial` value. This matches with the way it's done in the [TypeScript definitions for the native `reduce` and `reduceRight`](https://github.com/microsoft/TypeScript/blob/a514c7b15b4d826e99c658fbb6a4f6a9874e508f/lib/lib.es5.d.ts#L1271-L1282)

**If you changed the code, have you added enough unit tests?**

This is a TypeScript definitions fix, so there's no tests to add
