### PR TITLE
Update package.json for ts ESM node

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "browser": "src/modern-async.mjs",
   "module": "src/modern-async.mjs",
   "exports": {
+    "types": "./modern-async.d.ts",
     "import": "./src/modern-async.mjs",
     "require": "./dist/modern-async.cjs"
   },


### PR DESCRIPTION
This is required otherwise node yield 

> Could not find a declaration file for module 'modern-async'. '/Users/screamz/dev-workspace/perso/poc/iot/node_modules/.pnpm/modern-async@1.1.3/node_modules/modern-async/src/modern-async.mjs' implicitly has an 'any' type.
  There are types at '/Users/screamz/dev-workspace/perso/poc/iot/node_modules/modern-async/modern-async.d.ts', but this result could not be resolved when respecting package.json "exports". The 'modern-async' library may need to update its package.json or typings.ts(7016)