### PR TITLE
fix(asyncFind): return type should include undefined

### DIFF
--- a/modern-async.d.ts
+++ b/modern-async.d.ts
@@ -84,7 +84,7 @@ declare module "asyncFilter" {
 }
 declare module "asyncFind" {
     export default asyncFind;
-    function asyncFind<V>(iterable: Iterable<Promise<V> | V> | AsyncIterable<V>, iteratee: (value: V, index: number, iterable: Iterable<Promise<V> | V> | AsyncIterable<V>) => Promise<boolean> | boolean, queueOrConcurrency?: Queue | number, ordered?: boolean): Promise<V>;
+    function asyncFind<V>(iterable: Iterable<Promise<V> | V> | AsyncIterable<V>, iteratee: (value: V, index: number, iterable: Iterable<Promise<V> | V> | AsyncIterable<V>) => Promise<boolean> | boolean, queueOrConcurrency?: Queue | number, ordered?: boolean): Promise<V | undefined>;
     import Queue from "Queue";
 }
 declare module "asyncFindIndex" {


### PR DESCRIPTION
Similar to Array.prototype.find, the return value of `asyncFind` should be `Promise<T | undefined>`, rather than `Promise<T>`, since `undefined` will be returned in case there is no match found.